### PR TITLE
Feature to read RT Dose files

### DIFF
--- a/pyradise/data/__init__.py
+++ b/pyradise/data/__init__.py
@@ -1,5 +1,5 @@
 from .annotator import Annotator
-from .image import Image, ImageProperties, IntensityImage, SegmentationImage
+from .image import Image, ImageProperties, IntensityImage, DoseImage, SegmentationImage
 from .modality import Modality
 from .organ import Organ, OrganAnnotatorCombination
 from .subject import Subject

--- a/pyradise/data/image.py
+++ b/pyradise/data/image.py
@@ -752,7 +752,7 @@ class DoseImage(IntensityImage):
         modality (Union[Modality, str]): The image :class:`~pyradise.data.modality.Modality` or the modality's name.
     """
 
-    def __init__(self, image: Union[sitk.Image, itk.Image], modality: Union[Modality, str]) -> None:
+    def __init__(self, image: Union[sitk.Image, itk.Image], modality: Union[Modality, str], scaling_value: float) -> None:
 
         # Handle situation where RTDose intensity images are 4D - with a singleton dimensions.
         if image.GetDimension() == 4:
@@ -764,6 +764,10 @@ class DoseImage(IntensityImage):
                 image = image[:, :, 0, :]
             elif image.GetSize()[3] == 1:
                 image = image[:, :, :, 0]
+
+        # See here for why scaling is needed: https://dicom.innolitics.com/ciods/rt-dose/rt-dose/3004000e
+        image = sitk.Cast(image, sitk.sitkFloat32)
+        image = image * scaling_value
 
         super().__init__(image, modality)
 

--- a/pyradise/data/image.py
+++ b/pyradise/data/image.py
@@ -16,7 +16,7 @@ from .utils import str_to_annotator, str_to_modality, str_to_organ
 
 TransformInfo = TypeVar("TransformInfo")
 
-__all__ = ["Image", "IntensityImage", "SegmentationImage", "ImageProperties"]
+__all__ = ["Image", "IntensityImage", "SegmentationImage", "DoseImage", "ImageProperties"]
 
 
 class ImageProperties:
@@ -742,6 +742,30 @@ class SegmentationImage(Image):
             return f"SegmentationImage: {self.organ.get_name()}"
 
         return f"SegmentationImage: {self.organ.get_name()} / {self.annotator.get_name()}"
+
+
+class DoseImage(IntensityImage):
+    """A dose image class to specialize for properties of RTDose volumes.
+
+    Args:
+        image (Union[sitk.Image, itk.Image]): The image data as :class:`itk.Image` or :class:`SimpleITK.Image`.
+        modality (Union[Modality, str]): The image :class:`~pyradise.data.modality.Modality` or the modality's name.
+    """
+
+    def __init__(self, image: Union[sitk.Image, itk.Image], modality: Union[Modality, str]) -> None:
+
+        # Handle situation where RTDose intensity images are 4D - with a singleton dimensions.
+        if image.GetDimension() == 4:
+            if image.GetSize()[0] == 1:
+                image = image[0, :, :, :]
+            elif image.GetSize()[1] == 1:
+                image = image[:, 0, :, :]
+            elif image.GetSize()[2] == 1:
+                image = image[:, :, 0, :]
+            elif image.GetSize()[3] == 1:
+                image = image[:, :, :, 0]
+
+        super().__init__(image, modality)
 
 
 # Preparation for next release

--- a/pyradise/data/subject.py
+++ b/pyradise/data/subject.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 from warnings import warn
 
 from .annotator import Annotator
-from .image import Image, IntensityImage, SegmentationImage
+from .image import Image, IntensityImage, DoseImage, SegmentationImage
 from .modality import Modality
 from .organ import Organ
 
@@ -385,7 +385,7 @@ class Subject:
         Returns:
             List[Image]: A list of all images of the specified type.
         """
-        if image_type == IntensityImage:
+        if image_type == IntensityImage or image_type == DoseImage:
             return self.intensity_images
         elif image_type == SegmentationImage:
             return self.segmentation_images

--- a/pyradise/fileio/dicom_conversion.py
+++ b/pyradise/fileio/dicom_conversion.py
@@ -24,14 +24,14 @@ from pydicom.tag import Tag
 from pydicom.uid import (PYDICOM_IMPLEMENTATION_UID, ImplicitVRLittleEndian,
                          generate_uid)
 
-from pyradise.data import (IntensityImage, Modality, Organ, SegmentationImage,
+from pyradise.data import (IntensityImage, Modality, Organ, SegmentationImage, DoseImage,
                            Subject, str_to_modality)
 from pyradise.utils import (chunkify, convert_to_itk_image,
                             get_slice_direction, get_slice_position,
                             get_spacing_between_slices, load_dataset,
                             load_dataset_tag, load_datasets)
 
-from .series_info import (DicomSeriesImageInfo, DicomSeriesRegistrationInfo,
+from .series_info import (DicomSeriesImageInfo, DicomSeriesDoseInfo, DicomSeriesRegistrationInfo,
                           DicomSeriesRTSSInfo, RegistrationInfo, SeriesInfo)
 
 __all__ = [
@@ -2594,7 +2594,10 @@ class DicomImageSeriesConverter(Converter):
 
             # if no registration info is available, the image is added as is
             if reg_info is None:
-                image_ = IntensityImage(image, info.modality)
+                if isinstance(info, DicomSeriesDoseInfo):
+                    image_ = DoseImage(image, info.modality)
+                else:
+                    image_ = IntensityImage(image, info.modality)
                 image_.add_data({"SeriesInstanceUID": info.series_instance_uid})
                 images.append(image_)
 
@@ -2610,7 +2613,10 @@ class DicomImageSeriesConverter(Converter):
                     )
 
                 image = self._transform_image(image, reg_info.transform, is_intensity=True)
-                image_ = IntensityImage(image, info.modality)
+                if isinstance(info, DicomSeriesDoseInfo):
+                    image_ = DoseImage(image, info.modality)
+                else:
+                    image_ = IntensityImage(image, info.modality)
                 image_.add_data({"SeriesInstanceUID": info.series_instance_uid})
                 images.append(image_)
 

--- a/pyradise/fileio/dicom_conversion.py
+++ b/pyradise/fileio/dicom_conversion.py
@@ -2595,7 +2595,7 @@ class DicomImageSeriesConverter(Converter):
             # if no registration info is available, the image is added as is
             if reg_info is None:
                 if isinstance(info, DicomSeriesDoseInfo):
-                    image_ = DoseImage(image, info.modality)
+                    image_ = DoseImage(image, info.modality, info.scaling_value)
                 else:
                     image_ = IntensityImage(image, info.modality)
                 image_.add_data({"SeriesInstanceUID": info.series_instance_uid})
@@ -2614,7 +2614,7 @@ class DicomImageSeriesConverter(Converter):
 
                 image = self._transform_image(image, reg_info.transform, is_intensity=True)
                 if isinstance(info, DicomSeriesDoseInfo):
-                    image_ = DoseImage(image, info.modality)
+                    image_ = DoseImage(image, info.modality, info.scaling_value)
                 else:
                     image_ = IntensityImage(image, info.modality)
                 image_.add_data({"SeriesInstanceUID": info.series_instance_uid})

--- a/pyradise/fileio/series_info.py
+++ b/pyradise/fileio/series_info.py
@@ -21,6 +21,7 @@ __all__ = [
     "SegmentationFileSeriesInfo",
     "DicomSeriesInfo",
     "DicomSeriesImageInfo",
+    "DicomSeriesDoseInfo",
     "DicomSeriesRegistrationInfo",
     "DicomSeriesRTSSInfo",
     "ReferenceInfo",
@@ -415,6 +416,19 @@ class DicomSeriesImageInfo(DicomSeriesInfo):
             None
         """
         self._is_updated = True
+
+
+class DicomSeriesDoseInfo(DicomSeriesImageInfo):
+    """A :class:`DicomSeriesDoseInfo` class for DICOM Dose images. In addition to the information provided by the
+    :class:`DicomSeriesImageInfo` class, this class contains a flag to indicate the image is a Dose volume.
+
+    Args:
+        paths (Tuple[str, ...]): The paths to the DICOM image files to load.
+    """
+
+    def __init__(self, paths: Tuple[str, ...]) -> None:
+        super().__init__(paths)
+        self.is_dose_image = True
 
 
 # noinspection PyUnresolvedReferences

--- a/pyradise/fileio/series_info.py
+++ b/pyradise/fileio/series_info.py
@@ -428,6 +428,10 @@ class DicomSeriesDoseInfo(DicomSeriesImageInfo):
 
     def __init__(self, paths: Tuple[str, ...]) -> None:
         super().__init__(paths)
+        scaling_tag = [Tag(0x3004,0x000E)]
+        dataset = load_dataset_tag(self.path[0], scaling_tag)
+
+        self.scaling_value = str(dataset.get("DoseGridScaling", 1.0))
         self.is_dose_image = True
 
 


### PR DESCRIPTION
This change includes a new image type called DoseImage which then includes the scaling factor and also reduces the dimensions of dose volumes to be 3D (in case it is 4D by default). 

- [ x] New feature (non-breaking change which adds functionality)

## Testing Description
The existing tests have been run and nothing breaks (except for an unrelated issue: see 
unit/fileio/writing/test_dicom_series_subject_writer.py:64 (test__write_to_zip_4)
img_series_dcm = '/private/var/folders/yr/q_0gpqgs1lq_rtbttpk3n9bh0000gn/T/pytest-of-amithkamath/pytest-0/data10'
empty_folder = '/private/var/folders/yr/q_0gpqgs1lq_rtbttpk3n9bh0000gn/T/pytest-of-amithkamath/pytest-0/data11'

    def test__write_to_zip_4(img_series_dcm, empty_folder):
        ds, dicom_path = helper_get_ds(img_series_dcm)
        info = DicomSeriesImageInfo((dicom_path,))
        subject_writer = DicomSeriesSubjectWriter()
        subject_writer._write_to_zip((info,), (("dataset", ds),), empty_folder, "folder_name")
    
        with ZipFile(os.path.join(empty_folder, "folder_name.zip"), "r") as zip_ref:
            zip_ref.extractall(empty_folder)
    
        with open(dicom_path, "rb") as file:
            ds_original = pydicom.dcmread(file)
    
>       with open(os.path.join(empty_folder, "img_serie_14.dcm"), "rb") as f:
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/yr/q_0gpqgs1lq_rtbttpk3n9bh0000gn/T/pytest-of-amithkamath/pytest-0/data11/img_serie_14.dcm'

unit/fileio/writing/test_dicom_series_subject_writer.py:77: FileNotFoundError

- [ x] I have performed a self-review of my code and have run it by Mike already. 

