### PR TITLE
added IntraInterSubject registration

### DIFF
--- a/pyradise/process/__init__.py
+++ b/pyradise/process/__init__.py
@@ -33,5 +33,7 @@ from .registration import (InterSubjectRegistrationFilter,
                            InterSubjectRegistrationFilterParams,
                            IntraSubjectRegistrationFilter,
                            IntraSubjectRegistrationFilterParams,
+                           IntraInterSubjectRegistrationFilter,
+                           IntraInterSubjectRegistrationFilterParams,
                            RegistrationType)
 from .resampling import ResampleFilter, ResampleFilterParams


### PR DESCRIPTION
Added a combination of intra and inter Subject registration. Firstly, one sequence gets registered to a given reference image. Secondly, all or specific images get registered to the previously registered sequence.

- Removed resampling_interpolator, since it is a dead parameter

