### PR TITLE
Add RTMaskConformanceTest accuracy gate (separate CI job) (#1)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,65 @@
+name: Conformance
+
+# Runs the RTMaskConformanceTest analytical accuracy gate against
+# PyRaDiSe's RTSTRUCT->mask extraction path. The fixture (synthetic CT +
+# RTSTRUCT + analytic per-ROI ground-truth NIfTIs) is generated at the
+# start of the job -- no test data is committed to the repo.
+#
+# This is intentionally a separate job (not bolted onto an existing
+# test workflow) so the Conformance status appears as its own check on
+# PRs -- accuracy regressions are easy to spot and can be gated
+# independently of any other tests.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:  # manual "Run workflow" button on any branch
+
+env:
+  # Opt the JS actions used below into the Node.js 24 runtime ahead of
+  # GitHub's 2026-06-02 forced switch. Silences the end-of-job
+  # "Node.js 20 actions are deprecated" warning.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  conformance:
+    name: RTSTRUCT->mask conformance (PyRaDiSe)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          # rtmask-conformance requires Python >= 3.10. PyRaDiSe itself
+          # supports 3.8-3.11; we run conformance on 3.12 to match the
+          # cohort the rtmask-conformance fixture is published against.
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package + conformance extra
+        # PyRaDiSe imports `distutils`, removed from stdlib in 3.12;
+        # installing setuptools first provides the shim. (Same workaround
+        # used by the upstream benchmark harness's pyradise subenv.)
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools
+          python -m pip install -e ".[conformance]"
+
+      - name: Run conformance suite
+        run: pytest tests/test_conformance.py -v
+
+      - name: Upload conformance report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-debug
+          path: |
+            /tmp/pytest-of-runner/**/*.nii.gz
+            /tmp/pytest-of-runner/**/manifest.json
+          retention-days: 14
+          if-no-files-found: warn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,18 @@ dependencies = [
     'vtk',
 ]
 
+[project.optional-dependencies]
+# RTMaskConformanceTest -- analytical RTSTRUCT->NIfTI accuracy gate.
+# Opt-in: install with `pip install -e .[conformance]` to enable
+# tests/test_conformance.py and the Conformance CI job.
+# rtmask-conformance itself requires Python >= 3.10; pip will refuse to
+# install the extra on the older interpreters PyRaDiSe still supports,
+# which is the intended behavior.
+conformance = [
+    "rtmask-conformance @ git+https://github.com/brianmanderson/RTMaskConformanceTest",
+    "pytest>=7",
+]
+
 [project.urls]
 "Homepage" = "https://pyradise.readthedocs.io/"
 "Bug Tracker" = "https://github.com/ubern-mia/pyradise/issues"

--- a/tests/conformance.yaml
+++ b/tests/conformance.yaml
@@ -1,0 +1,28 @@
+# RTMaskConformanceTest threshold overrides for PyRaDiSe.
+#
+# Defaults (Dice >= 0.95, sDSC1 >= 0.95, HD95 <= 2 mm, MSD <= 0.5 mm,
+# vol_err <= 3%) ship inside the rtmask-conformance package; per-primitive
+# overrides shallow-merge over those.
+#
+# Each relaxation below is documented: what PyRaDiSe currently produces,
+# why, and the path back to the published default. If a future PyRaDiSe
+# change lifts the actual metric, the corresponding line here should be
+# removed (or its number tightened) so the conformance gate gets stricter.
+
+schema_version: 1
+
+primitives:
+  cube:
+    # First CI run: Dice 0.9835 (< 0.99 default) and volume_rel_err 0.0336
+    # (> 0.03 default). Surface metrics still hit the published defaults
+    # (sDSC@1mm = 0.999, HD95 = 1.0 mm, MSD = 0.33 mm) so the cube
+    # boundary is in the right place.
+    #
+    # These numbers are bit-identical to DicomRTTool's first run on the
+    # same fixture, which strongly implies PyRaDiSe's rasterizer is
+    # cv2.fillPoly (boundary-inclusive: every voxel touched by the
+    # polygon is filled, gaining ~3.4% volume from the boundary pixels
+    # along each face). Tighten back to dice >= 0.99 / vol_err <= 0.03
+    # once the rasterizer honours a half-voxel-shrink contour.
+    dice: 0.98
+    volume_rel_err: 0.034

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1,0 +1,212 @@
+"""Conformance test: PyRaDiSe vs RTMaskConformanceTest analytic ground truth.
+
+Generates the RTMaskConformanceTest fixture (synthetic CT + RTSTRUCT +
+analytic per-ROI NIfTI ground truth), drives PyRaDiSe through its
+``SubjectDicomCrawler`` -> ``IterableSubjectLoader`` API to produce per-ROI
+masks, and asserts each ROI passes the published conformance thresholds
+(Dice, Surface DSC @ 1 mm, HD95, MSD, relative volume error).
+
+The ground-truth NIfTIs are computed analytically (sub-voxel quadrature
+against the closed-form shape definitions) -- independent of any
+rasterizer -- so a Dice failure here is a real accuracy regression in
+PyRaDiSe's segmentation extraction path, not a discretization artifact.
+
+This module is opt-in: it imports the third-party ``rtmask_conformance``
+package, installed via the ``conformance`` extra::
+
+    pip install -e .[conformance]
+
+If the package is not installed the entire module is skipped via
+``pytest.importorskip``, so the default ``pytest`` run is unaffected.
+``rtmask_conformance`` itself requires Python >= 3.10; on older
+interpreters the extra cannot be installed and the test is skipped.
+
+Threshold overrides go in ``tests/conformance.yaml`` (set
+``RTMASK_CONFORMANCE_CONFIG`` to use a different file). See
+https://github.com/brianmanderson/RTMaskConformanceTest for the schema.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+rtmask_conformance = pytest.importorskip(
+    "rtmask_conformance",
+    reason="install the `conformance` extra: pip install -e .[conformance]",
+)
+
+import SimpleITK as sitk  # noqa: E402
+
+from rtmask_conformance import CONFORMANCE_ROIS, generate_fixture, load_config  # noqa: E402
+from rtmask_conformance.generate import GenerateOptions  # noqa: E402
+from rtmask_conformance.verify import Status, evaluate_one  # noqa: E402
+
+# n_quadrature=2 (8 sub-voxel samples) makes the GT masks stable to ~1
+# voxel of partial-volume disagreement on the boundary -- well below the
+# pass thresholds and an order of magnitude faster than n=8.
+_FIXTURE_QUADRATURE = 2
+
+_CONFIG_YAML = Path(__file__).with_name("conformance.yaml")
+
+
+def _stage_dicom_inputs(rtstruct: Path, image_folder: Path, stage: Path) -> None:
+    """Hard-link (or copy) the CT slices + RTSTRUCT into a single directory.
+
+    PyRaDiSe's ``SubjectDicomCrawler`` walks a directory tree and groups by
+    study/series; it can't accept the CT folder and RTSTRUCT path as
+    separate arguments. Mirrors the staging pattern from the upstream
+    benchmark adapter at PythonCode/subenvs/pyradise/run_forward.py.
+    """
+    stage.mkdir(parents=True, exist_ok=True)
+    for src in image_folder.glob("*.dcm"):
+        dst = stage / src.name
+        try:
+            os.link(src, dst)
+        except OSError:
+            shutil.copy2(src, dst)
+    rt_dst = stage / rtstruct.name
+    try:
+        os.link(rtstruct, rt_dst)
+    except OSError:
+        shutil.copy2(rtstruct, rt_dst)
+
+
+def _extract_sitk_image(seg) -> "sitk.Image | None":
+    """Pull the underlying SimpleITK image out of a PyRaDiSe segmentation
+    container. Different point releases expose different attribute names;
+    try the documented ones in order.
+    """
+    for attr in ("get_image_data", "get_image"):
+        if hasattr(seg, attr):
+            try:
+                v = getattr(seg, attr)()
+                if v is not None:
+                    return v
+            except Exception:
+                continue
+    return None
+
+
+@pytest.fixture(scope="session")
+def conformance_fixture(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Synthetic CT + RTSTRUCT + analytic GT NIfTIs."""
+    out = tmp_path_factory.mktemp("rtmask_conformance_fixture")
+    generate_fixture(out, options=GenerateOptions(n_quadrature=_FIXTURE_QUADRATURE))
+    return out
+
+
+@pytest.fixture(scope="session")
+def pyradise_predictions(
+    conformance_fixture: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Path:
+    """Run PyRaDiSe against the fixture; emit one binary <roi>.nii.gz per ROI.
+
+    The verifier expects ``<predictions>/<roi>.nii.gz`` per ROI, so we save
+    each subject->organ segmentation under its ROI name from PyRaDiSe.
+    """
+    pred_dir = tmp_path_factory.mktemp("pyradise_preds")
+
+    # Stage CT + RTSTRUCT in one directory for the crawler.
+    stage = Path(tempfile.mkdtemp(prefix="pyradise_stage_"))
+    try:
+        _stage_dicom_inputs(
+            rtstruct=conformance_fixture / "rtstruct" / "primitives_planar.dcm",
+            image_folder=conformance_fixture / "refct",
+            stage=stage,
+        )
+
+        # Lazy imports keep import-time errors out of pytest collection.
+        from pyradise.fileio import (
+            IterableSubjectLoader,
+            SimpleModalityExtractor,
+            SubjectDicomCrawler,
+        )
+
+        modality_extractor = SimpleModalityExtractor(modalities=("CT",))
+        crawler = SubjectDicomCrawler(
+            path=str(stage),
+            modality_extractor=modality_extractor,
+        )
+        series_infos = crawler.execute()
+        if not series_infos:
+            pytest.fail("PyRaDiSe crawler discovered no series in the staged fixture.")
+
+        # IterableSubjectLoader expects Tuple[Tuple[SeriesInfo, ...], ...]
+        # (subjects -> series-within-subject). The crawler returns a flat
+        # tuple for a single-subject input -- wrap it once more.
+        if not isinstance(series_infos[0], tuple):
+            series_infos = (tuple(series_infos),)
+
+        loader = IterableSubjectLoader(info=series_infos)
+        n_written = 0
+        for subject in loader:
+            organs = subject.get_organs() if hasattr(subject, "get_organs") else []
+            for organ in organs:
+                roi_name = organ.get_name() if hasattr(organ, "get_name") else str(organ)
+                try:
+                    seg = subject.get_image_by_organ(organ)
+                except Exception:
+                    continue
+                if seg is None:
+                    continue
+                image = _extract_sitk_image(seg)
+                if image is None:
+                    continue
+                sitk.WriteImage(image, str(pred_dir / f"{roi_name}.nii.gz"))
+                n_written += 1
+
+        if n_written == 0:
+            pytest.fail("PyRaDiSe yielded no per-ROI masks for any subject.")
+    finally:
+        shutil.rmtree(stage, ignore_errors=True)
+
+    return pred_dir
+
+
+@pytest.fixture(scope="session")
+def conformance_config():
+    """Resolution: env var > tests/conformance.yaml > package defaults."""
+    config_path = os.environ.get("RTMASK_CONFORMANCE_CONFIG")
+    if config_path is None and _CONFIG_YAML.is_file():
+        config_path = str(_CONFIG_YAML)
+    return load_config(config_path)
+
+
+@pytest.mark.parametrize("roi", CONFORMANCE_ROIS)
+def test_pyradise_conformance(
+    roi: str,
+    conformance_fixture: Path,
+    pyradise_predictions: Path,
+    conformance_config,
+):
+    """Each ROI: PyRaDiSe's mask must match analytic ground truth within
+    the published thresholds (Dice, Surface DSC, HD95, MSD, volume error).
+    """
+    pred_path = pyradise_predictions / f"{roi}.nii.gz"
+    gt_path = conformance_fixture / "groundtruth" / f"{roi}.nii.gz"
+    assert gt_path.is_file(), f"fixture incomplete: {gt_path}"
+    if not pred_path.is_file():
+        pytest.fail(
+            f"PyRaDiSe produced no mask for {roi!r}. "
+            f"Predictions dir: {sorted(p.name for p in pyradise_predictions.iterdir())}"
+        )
+
+    result = evaluate_one(roi, pred_path, gt_path, conformance_config)
+
+    if result.status == Status.GEOMETRY_MISMATCH:
+        pytest.fail(
+            f"{roi}: geometry mismatch between PyRaDiSe output and ground truth: "
+            f"{result.geometry_diagnostic}"
+        )
+    if result.status != Status.PASS:
+        pytest.fail(
+            f"{roi}: {result.status.value}\n"
+            f"  violations: {result.violations}\n"
+            f"  metrics:    {result.metrics}\n"
+            f"  thresholds: {result.thresholds}"
+        )


### PR DESCRIPTION
* Add RTMaskConformanceTest accuracy gate (separate CI job)

Wires PyRaDiSe against the rtmask-conformance suite at https://github.com/brianmanderson/RTMaskConformanceTest. The suite generates a synthetic CT + RTSTRUCT with seven analytically-defined ROIs (sphere, cube, cylinder, ellipsoid, torus, hollow_sphere, straw) and per-ROI ground-truth NIfTIs computed via sub-voxel quadrature against the closed-form shape definitions -- independent of any rasterizer.

Pieces:

* pyproject: new `conformance` optional extra. rtmask-conformance requires Python >= 3.10, so pip refuses to install the extra on PyRaDiSe's older supported interpreters (3.8 / 3.9), which is the intended behavior -- only CI / dev users on 3.10+ get the gate.

* tests/test_conformance.py: opt-in pytest module (skips via importorskip when the extra isn't installed). Stages CT + RTSTRUCT in one folder for SubjectDicomCrawler (mirrors the staging pattern from the upstream benchmark adapter), drives PyRaDiSe through its documented loader API to produce per-ROI masks, and asserts each ROI passes Dice / Surface DSC@1mm / HD95 / MSD / volume thresholds.

* tests/conformance.yaml: empty for v0.1 -- populate from the first CI run if any ROI lands just under the published defaults.

* .github/workflows/conformance.yml: separate Conformance CI job (ubuntu-latest, py3.12) so the check appears as its own status on PRs without expanding any other test workflow. Pre-installs setuptools to work around PyRaDiSe's distutils import on Python 3.12 (same workaround the upstream benchmark harness uses).

Why this matters: the analytic ground truth comes from rtmask_validation's partial-volume sub-voxel quadrature voxelizer, which is independent of PyRaDiSe's segmentation extraction path. So a Dice failure here is a real accuracy regression, not a tautology.



---------

## Description
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Added a new conformance test with 7 analytically created ROIs (cube, straw, cylinder, sphere, hollow sphere, ellipsoid, torus) to ensure that future changes are monitored.

## Type of change
Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Testing Description
Please include a description how the changes have been tested.
New check add for Github Actions.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have performed code testing
- [ ] Will this be part of a product update / new version? If yes, please write one phrase about this update.
If needed? Summary above
